### PR TITLE
Update for metadata for gnome-shell 3.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It shows notifications about numlock or capslock state change.
 
 ![Screenshot](https://github.com/kazysmaster/gnome-shell-extension-lockkeys/raw/master/screenshot.png)
 
-The master branch supports gnome-shell 3.16
+The master branch supports gnome-shell 3.20
 
 The extension is available at http://extensions.gnome.org
 

--- a/lockkeys@vaina.lt/metadata.json
+++ b/lockkeys@vaina.lt/metadata.json
@@ -1,9 +1,9 @@
 {
-   "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18"], 
+   "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18", "3.20"], 
    "uuid": "lockkeys@vaina.lt", 
    "name": "Lock Keys", 
    "description": "Numlock & Capslock status on the panel", 
    "url": "https://github.com/kazysmaster/gnome-shell-extension-lockkeys",
    "original-authors": "Kazimieras Vaina, Pierre Ossman, erguille, jonnius, Philipp Wolfer, Mariusz Lisowski, Cristian Beroiza, warmsun0220, Rasmus Kaj, Pablo Martin-Gomez Bouska",
-   "version" : 23
+   "version" : 24
 }


### PR DESCRIPTION
I've tested the extension on gnome 3.20. Works flawless.