### PR TITLE
Add portuguese translation

### DIFF
--- a/pt_BR.po
+++ b/pt_BR.po
@@ -1,0 +1,67 @@
+# Portuguese from Brazil
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-shell-extension-lockkeys\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-02-10 00:53+0200\n"
+"PO-Revision-Date: 2018-02-10 01:11-0200\n"
+"Last-Translator: Luiz Augusto Nickel Lino <luizaugustonickel@gmail.com>\n"
+"Language-Team: Portuguese <luizaugustonickel@gmail.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"Language: pt_BR\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: prefs.js:28
+msgid "Indicator Style"
+msgstr "Estilo do indicador"
+
+#: prefs.js:28
+msgid "Change indicator display options"
+msgstr "Mudar exibição de opções do indicador"
+
+#: prefs.js:29
+msgid "Num-Lock Only"
+msgstr "Num-Lock somente"
+
+#: prefs.js:29
+msgid "Caps-Lock Only"
+msgstr "Caps-Lock somente"
+
+#: prefs.js:29
+msgid "Both"
+msgstr "Ambos"
+
+#: prefs.js:29
+msgid "Show/Hide"
+msgstr "Mostrar/Ocultar"
+
+#: prefs.js:30
+msgid "Notifications"
+msgstr "Notificações"
+
+#: prefs.js:30
+msgid "Show notifications when state changes"
+msgstr "Mostrar notificações quando houver mudança de estado"
+
+#: extension.js:78 extension.js:152
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: extension.js:82 extension.js:158
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: extension.js:87
+msgid "Settings"
+msgstr "Configurações"
+
+#: extension.js:217
+msgid "On"
+msgstr "Ligado"
+
+#: extension.js:217
+msgid "Off"
+msgstr "Desligado"


### PR DESCRIPTION
I recently used this plugin on my environment, and I loved it. Looking at the source, I decided to add a translation for Portuguese :) 

**PS** : This translation works for Portuguese based places, such as Brazil, Portugal itself etc.