### PR TITLE
Fix exception that occurs on init when actor is undefined / null

### DIFF
--- a/lockkeys@vaina.lt/extension.js
+++ b/lockkeys@vaina.lt/extension.js
@@ -209,7 +209,8 @@ HighlightIndicator.prototype = {
 	},
 	
 	displayState: function(actor, numlock_state, capslock_state) {
-		actor.visible = true;
+		if (actor)
+			actor.visible = true;
 		
 		if (numlock_state)
 			this.numIcon.set_gicon( this.panelButton._getCustIcon('numlock-enabled-symbolic') );
@@ -240,7 +241,8 @@ ShowhideIndicator.prototype = {
 	},
 	
 	displayState: function(actor, numlock_state, capslock_state) {
-		actor.visible = numlock_state || capslock_state;
+		if (actor)
+			actor.visible = numlock_state || capslock_state;
 	
 		if (numlock_state)
 			this.numIcon.show();


### PR DESCRIPTION
So it appears that my previous mod created a bug that causes the extension to throw an exception on init.  The error / warning icon can be clearly seen in the gnome tweak tool and an error is logged for it.  These extra few lines of code appear to resolve the situation.

I apologize for not catching this earlier.