### PR TITLE
Fix final "object.actor" is deprecated instance

### DIFF
--- a/lockkeys@vaina.lt/extension.js
+++ b/lockkeys@vaina.lt/extension.js
@@ -76,7 +76,7 @@ const LockKeysIndicator = new Lang.Class({
 		layoutManager.add_child(this.numIcon);
 		layoutManager.add_child(this.capsIcon);
 
-		this.actor.add_child(layoutManager);
+		this.add_child(layoutManager);
 
 		this.numMenuItem = new PopupMenu.PopupSwitchMenuItem(_("Num Lock"), false, { reactive: false });
 		this.menu.addMenuItem(this.numMenuItem);


### PR DESCRIPTION
In reference to this [issue](https://github.com/kazysmaster/gnome-shell-extension-lockkeys/issues/68). This seems to fix things on my end; no more "object.actor" deprecated messages.