### PR TITLE
Reestablish compatibility with GNOME <3.34

### DIFF
--- a/lockkeys@vaina.lt/extension.js
+++ b/lockkeys@vaina.lt/extension.js
@@ -87,7 +87,11 @@ const LockKeysIndicator = new Lang.Class({
 		layoutManager.add_child(this.numIcon);
 		layoutManager.add_child(this.capsIcon);
 
-		this.add_child(layoutManager);
+		if (parseFloat(imports.misc.config.PACKAGE_VERSION) >= 3.34) {
+			this.add_child(layoutManager);
+		} else {
+			this.actor.add_child(layoutManager);
+		}
 
 		this.numMenuItem = new PopupMenu.PopupSwitchMenuItem(_("Num Lock"), false, { reactive: false });
 		this.menu.addMenuItem(this.numMenuItem);


### PR DESCRIPTION
this.actor was deprecated but is still required for older GNOME versions.