### PR TITLE
Added option to Show/Hide capslock only

### DIFF
--- a/lockkeys@vaina.lt/extension.js
+++ b/lockkeys@vaina.lt/extension.js
@@ -34,6 +34,7 @@ const STYLE_NUMLOCK_ONLY = 'numlock';
 const STYLE_CAPSLOCK_ONLY = 'capslock';
 const STYLE_BOTH = 'both';
 const STYLE_SHOWHIDE = 'show-hide';
+const STYLE_SHOWHIDE_CAPSLOCK = 'show-hide-capslock';
 const NOTIFICATIONS = 'notification-preferences';
 const NOTIFICATIONS_OFF = 'off';
 const NOTIFICATIONS_ON = 'on';
@@ -144,6 +145,8 @@ class LockKeysIndicator extends PanelMenu.Button {
 	handleSettingsChange(actor, event) {
 		if (this.config.isVisibilityStyle())
 			this.indicatorStyle = new VisibilityIndicator(this);
+		else if (this.config.isVisibilityStyleCapslock())
+			this.indicatorStyle = new VisibilityIndicatorCapslock(this);
 		else
 			this.indicatorStyle = new HighlightIndicator(this);
 		this.updateState();
@@ -294,6 +297,25 @@ class VisibilityIndicator extends GObject.Object{
 	}
 });
 
+const VisibilityIndicatorCapslock = GObject.registerClass(
+class VisibilityIndicatorCapslock extends GObject.Object{
+	_init(panelButton) {
+		this.panelButton = panelButton;
+		this.config = panelButton.config;
+		this.capsIcon = panelButton.capsIcon;
+	}
+
+	displayState(numlock_state, capslock_state) {
+		if (capslock_state) {
+			this.capsIcon.set_gicon(this.panelButton.getCustIcon('capslock-enabled-symbolic'));
+			this.capsIcon.show();
+		} else
+			this.capsIcon.hide();
+
+		this.panelButton.visible = capslock_state;
+	}
+});
+
 const Configuration = GObject.registerClass(
 class Configuration extends GObject.Object{
 	_init() {
@@ -333,5 +355,10 @@ class Configuration extends GObject.Object{
 	isVisibilityStyle() {
 		let widget_style = this.settings.get_string(STYLE);
 		return widget_style == STYLE_SHOWHIDE;
+	}
+
+	isVisibilityStyleCapslock() {
+		let widget_style = this.settings.get_string(STYLE);
+		return widget_style == STYLE_SHOWHIDE_CAPSLOCK;
 	}
 });

--- a/lockkeys@vaina.lt/extension.js
+++ b/lockkeys@vaina.lt/extension.js
@@ -278,17 +278,18 @@ class VisibilityIndicator extends GObject.Object{
 		this.config = panelButton.config;
 		this.numIcon = panelButton.numIcon;
 		this.capsIcon = panelButton.capsIcon;
+
+		this.numIcon.set_gicon(this.panelButton.getCustIcon('numlock-enabled-symbolic'));
+		this.capsIcon.set_gicon(this.panelButton.getCustIcon('capslock-enabled-symbolic'));
 	}
 
 	displayState(numlock_state, capslock_state) {
 		if (numlock_state) {
-			this.numIcon.set_gicon(this.panelButton.getCustIcon('numlock-enabled-symbolic'));
 			this.numIcon.show();
 		} else
 			this.numIcon.hide();
 
 		if (capslock_state) {
-			this.capsIcon.set_gicon(this.panelButton.getCustIcon('capslock-enabled-symbolic'));
 			this.capsIcon.show();
 		} else
 			this.capsIcon.hide();
@@ -303,11 +304,12 @@ class VisibilityIndicatorCapslock extends GObject.Object{
 		this.panelButton = panelButton;
 		this.config = panelButton.config;
 		this.capsIcon = panelButton.capsIcon;
+		
+		this.capsIcon.set_gicon(this.panelButton.getCustIcon('capslock-enabled-symbolic'));
 	}
 
 	displayState(numlock_state, capslock_state) {
 		if (capslock_state) {
-			this.capsIcon.set_gicon(this.panelButton.getCustIcon('capslock-enabled-symbolic'));
 			this.capsIcon.show();
 		} else
 			this.capsIcon.hide();

--- a/lockkeys@vaina.lt/lockkeys.pot
+++ b/lockkeys@vaina.lt/lockkeys.pot
@@ -59,6 +59,10 @@ msgstr ""
 msgid "Show/Hide"
 msgstr ""
 
+#: prefs.js:39
+msgid "Show/Hide Caps-Lock Only"
+msgstr ""
+
 #: prefs.js:40
 msgid "Notifications"
 msgstr ""

--- a/lockkeys@vaina.lt/prefs.js
+++ b/lockkeys@vaina.lt/prefs.js
@@ -15,6 +15,7 @@ const STYLE_NUMLOCK_ONLY = 'numlock';
 const STYLE_CAPSLOCK_ONLY = 'capslock';
 const STYLE_BOTH = 'both';
 const STYLE_SHOWHIDE = 'show-hide';
+const STYLE_SHOWHIDE_CAPSLOCK = 'show-hide-capslock';
 const NOTIFICATIONS = 'notification-preferences';
 const NOTIFICATIONS_OFF = 'off';
 const NOTIFICATIONS_ON = 'on';
@@ -34,7 +35,8 @@ function buildPrefsWidget() {
 		[STYLE_NUMLOCK_ONLY]: _("Num-Lock Only"),
 		[STYLE_CAPSLOCK_ONLY]: _("Caps-Lock Only"),
 		[STYLE_BOTH]: _("Both"),
-		[STYLE_SHOWHIDE]: _("Show/Hide")
+		[STYLE_SHOWHIDE]: _("Show/Hide"),
+        [STYLE_SHOWHIDE_CAPSLOCK]: _("Show/Hide Caps-Lock Only")
 	});
 
 	let notifications_style = createComboBox(NOTIFICATIONS, _("Notifications"), _("Show notifications when state changes"), {


### PR DESCRIPTION
I liked the Show/Hide option but didn't like that Numlock is always showing in the panel because it's always on.
This PR adds the option to only show/hide the Capslock status in the panel.