### PR TITLE
Make toggle switches greyed out

### DIFF
--- a/lockkeys@vaina.lt/extension.js
+++ b/lockkeys@vaina.lt/extension.js
@@ -77,9 +77,11 @@ const LockKeysIndicator = GObject.registerClass({
         this.add_child(layoutManager);
 
         this.numMenuItem = new PopupMenu.PopupSwitchMenuItem(_("Num Lock"), false, { reactive: false });
+        this.numMenuItem._switch.set_opacity(122);
         this.menu.addMenuItem(this.numMenuItem);
 
         this.capsMenuItem = new PopupMenu.PopupSwitchMenuItem(_("Caps Lock"), false, { reactive: false });
+        this.capsMenuItem._switch.set_opacity(122);
         this.menu.addMenuItem(this.capsMenuItem);
 
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());


### PR DESCRIPTION
The current toggle switches have vivid colors. This makes the user think caps lock and num lock can be toggled from the extension. However, the toggle switches can't be toggled with a mouse click.

This change makes the toggle switches greyed out.

![Before](https://github.com/user-attachments/assets/27ff98a6-1a22-4a5e-a152-c0c5d248a7c5)
*Before*

![After](https://github.com/user-attachments/assets/0d20a905-89c6-47fb-8f0f-52c51d29ce31)
*After*